### PR TITLE
Update actions to always run

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,12 +17,15 @@ jobs:
           pip install GitPython~=2.1
           pip install .
       - name: Prospector Linting
+        if: always()
         run: |
           pip install prospector>=1.1
           c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs prospector; fi
       - name: Commit Message Linting
+        if: always()
         run: python ci/test_commit_message.py    
       - name: Security Linting
+        if: always()
         run: |
           pip install bandit~=1.6
           c=`python ci/evaluate_docs.py`; if [ -z $c ]; then echo "No .py files to lint"; else echo $c | xargs bandit; fi


### PR DESCRIPTION
We want the github action steps to always run
despite the previous test failing. We may need
to do this with different run items instead of
calling each test as a step to a full PR check.

Signed-off-by: Rose Judge <rjudge@vmware.com>